### PR TITLE
refresh table after makeVERequest

### DIFF
--- a/Frontend/src/app/components/ve-request-table/ve-request-table.component.ts
+++ b/Frontend/src/app/components/ve-request-table/ve-request-table.component.ts
@@ -119,9 +119,9 @@ export class VeRequestTableComponent {
             console.log(err);
           }
         }
+      }, () => {
+        this.refresh()
       });
-
-      return;
     })
   }
 


### PR DESCRIPTION
Mir ist aufgefallen, dass die Tabelle nach einer neuen Bedarfsmeldung nicht neu geladen wird.